### PR TITLE
Black Duck: Upgrade jasmine-node to version 3.0.0 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "express": "^4.16.2",
     "fs": "0.0.1-security",
     "jasmine": "^3.1.0",
-    "jasmine-node": "^1.14.5",
+    "jasmine-node": "^3.0.0",
     "pack-zip": "^0.2.2",
     "request": "^2.83.0"
   },


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade jasmine-node from version 1.16.2 to 3.0.0 in order to fix security vulnerabilities:

The direct dependency jasmine-node/1.16.2 has 2 vulnerabilities in child dependencies (max score 9.8).


| Parent | Child Component | Vulnerability | Score |  Policy | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| jasmine-node/1.16.2 | underscore/1.9.2 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2021-1143/overview" target="_blank">BDSA-2021-1143</a> | <span style="color:Red">7.3</span> | Vulnerability Score Greater Than Or Equal to 6 | The Underscore Javascript library contains an arbitrary code execution vulnerability.  This allows an attacker to create malicious content that, if processed by Underscore may lead to the execution of | 1.9.2 |
| jasmine-node/1.16.2 | growl/1.7.0 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/CVE-2017-16042/overview" target="_blank">CVE-2017-16042</a> | <span style="color:DarkRed">9.8</span> | Vulnerability Score Greater Than Or Equal to 6 | Growl adds growl notification support to nodejs. Growl before 1.10.2 does not properly sanitize input before passing it to exec, allowing for arbitrary command execution. | 1.7.0 |


